### PR TITLE
OPS-1059 Allow Janus to work on serverless

### DIFF
--- a/janus.py
+++ b/janus.py
@@ -30,7 +30,11 @@ if __name__ == '__main__':
         exit(0)
 
     # Get variables from the metadata server
-    instance_name = get_metadata('instance', 'hostname')
+    try:
+        instance_name = get_metadata('instance', 'hostname')
+    except SystemExit:
+        print('Warning: Could not fetch metadata for instance hostname. Using default value "unknown".')
+        instance_name = 'unknown'
     project_id = get_metadata('project', 'project-id')
     project_and_instance_name = '{}.{}'.format(project_id, instance_name)[:64]
     token = get_metadata('instance', 'service-accounts/default/identity?format=standard&audience=gcp')


### PR DESCRIPTION
Ticket: https://ripplehealthgroup.atlassian.net/jira/software/projects/OPS/boards/6?selectedIssue=OPS-1059

blog post: https://www.doit.com/assume-an-aws-role-from-a-google-cloud-without-using-iam-keys/

Janus allows keyless auth from GCP to AWS via a compute engine instance. Cloud Run does not allow you access to the underlying host metadata, change allows for Janus to work on serverless.